### PR TITLE
Added timelapse option and sample config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-config.py
+roboto
 *.pyc
 *.jpg
 *.ttf
-
+config.py
+seed-it.sh

--- a/README.md
+++ b/README.md
@@ -18,17 +18,15 @@ $ sudo pip install -r requirements.txt
 
 * Update your access keys
 
-Now add your Twitter keys into a config.py file:
+Now add your Twitter keys into the config.py file:
 
-```
-config = {"ckey": "", "csecret": "", "akey": "", "asecret": "", "working_directory": "./", "image_quality": 35 , "tweet": True}
-```
-
-> For testing without Tweeting you can set `tweet` to `False` in the `config.py` file.
+> For testing without Tweeting you can set `enabled` to `False` in the `twitter` section of `config.py`.
 
 * Get the Roboto font from:
 
 https://material.io/guidelines/resources/roboto-noto-fonts.html
+
+* To enable timelapse set `timelapse` to `True` in `config.py`.  This will create a series of timestamped images in the `images` directory which can later be combined to create a video.
 
 * For scheduling the code - use `cron` and this entry:
 
@@ -36,5 +34,4 @@ https://material.io/guidelines/resources/roboto-noto-fonts.html
 */10 08-20 * * * /home/pi/seeds2/seed-it.sh
 ```
 
-That runs once every 10 minutes between 8am and 8pm.
-
+That runs once every 10 minutes between 8am and 8:50pm.

--- a/config.py
+++ b/config.py
@@ -1,0 +1,25 @@
+config = {
+            "twitter": {
+                "enabled": True,
+                "message" : "Internet of seeds #InternetOfSeeds",
+                "ckey": "",
+                "csecret": "",
+                "akey": "",
+                "asecret": ""
+            },
+            "camera": {
+                "image_directory": "./images/",
+                "encoding": "jpeg",
+                "width": 2592,
+                "height": 1944,
+                "image_quality": 100,
+                "preview_time": 1,
+                "verticalflip": False,
+                "horizontalflip": False
+            },
+            "text": {
+                "colour": (255, 255, 255),
+                "size": 48
+            },
+            "timelapse": False,
+        }

--- a/images/.gitignore
+++ b/images/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 import picamera
 import io
+import os
+import sys
 import time
 import tweepy
 
@@ -8,37 +10,47 @@ from cputemp import CpuTemp
 from PIL import Image, ImageFont, ImageDraw
 from tweeter import Tweeter
 
-def read_image(preview_time):
+def read_image():
     stream = io.BytesIO()
     with picamera.PiCamera() as camera:
         camera.start_preview()
-        camera.vflip = True
-        camera.hflip = True
-        camera.resolution = (1920, 1080)
+        camera.vflip = config["camera"]["verticalflip"]
+        camera.hflip = config["camera"]["horizontalflip"]
+        camera.resolution = (config["camera"]["width"], config["camera"]["height"])
         # Camera warm-up time
-        time.sleep(preview_time)
-        camera.capture(stream, 'jpeg')
+        time.sleep(config["camera"]["preview_time"])
+        camera.capture(stream, config["camera"]["encoding"])
     return stream
 
 def watermark(filename, msg):
     img = Image.open(filename)
     draw = ImageDraw.Draw(img)
-    font = ImageFont.truetype('roboto/Roboto-Regular.ttf', 36)
-    draw.text((10, 10), msg, (0, 0, 0), font=font)
+    font = ImageFont.truetype('roboto/Roboto-Regular.ttf', config["text"]["size"])
+    draw.text((10, 10), msg, config["text"]["colour"], font=font)
     img.save(filename) 
 
 if(__name__=="__main__"):
-    preview_time = 1
-    stream = read_image(preview_time)
 
-    filename = "image.jpg"
+    #need to check that the target iamge path exists
+    if not os.path.exists(config["camera"]["image_directory"]):
+        pwd=os.getcwd()
+        sys.exit("Error: Please ensure that " + pwd + config["camera"]["image_directory"][1:] + " exists.")
+
+    stream = read_image()
+    
+    #use unix timestamp for filename to ease sorting in case timelapse is also enabled
+    filename = config["camera"]["image_directory"] + str(int(time.time())) + "." + config["camera"]["encoding"]
+    
     with open(filename, 'wb') as file:
         file.write(stream.getvalue())
     cpu = CpuTemp()
     msg = "CPU temp: " + cpu.read() + "C"
     watermark(filename, msg)
 
-    if config["tweet"] == True:
-        tweeter = Tweeter(config, tweepy)
-        tweeter.send(filename, "Internet of Seeds Mark II")
+    if config["twitter"]["enabled"] == True:
+        tweeter = Tweeter(config["twitter"], tweepy)
+        tweeter.send(filename, config["twitter"]["message"])
 
+    #if we arent timelapsing no need to keep the file
+    if config["timelapse"] != True:
+        os.remove(filename)

--- a/seed-it.sh
+++ b/seed-it.sh
@@ -2,4 +2,3 @@
 
 cd /home/pi/seeds2/
 python main.py
-rm image.jpg


### PR DESCRIPTION
The largest change in terms of refactoring is moving a lot more of the config into config.py so that users can change the config without having to touch main.py.  Also tried to enhance the readability of config.py.

A timelapse option has been added which will keep the tweeted images in the images directory to enable the user to pull the images of their harvest into a timelapse should they wish to.

Finally, corrected a typo in the cron description.